### PR TITLE
Remove redirect route name in fastapi integration

### DIFF
--- a/fastapi_oauth20/integrations/fastapi.py
+++ b/fastapi_oauth20/integrations/fastapi.py
@@ -30,21 +30,15 @@ class FastAPIOAuth20:
         client: OAuth20Base,
         *,
         redirect_uri: str | None = None,
-        redirect_route_name: str | None = None,
     ):
         """
         OAuth2 authorization callback dependency injection
 
         :param client: A client base on OAuth20Base.
         :param redirect_uri: OAuth2 callback full URL.
-        :param redirect_route_name: OAuth2 callback route name, as defined by the route decorator 'name' parameter.
         """
-        assert (redirect_uri is None and redirect_route_name is not None) or (
-            redirect_uri is not None and redirect_route_name is None
-        ), 'FastAPIOAuth20 redirect_uri and oauth2_callback_route_name cannot be defined at the same time.'
         self.client = client
         self.redirect_uri = redirect_uri
-        self.redirect_route_name = redirect_route_name
 
     async def __call__(
         self,
@@ -60,15 +54,10 @@ class FastAPIOAuth20:
                 detail=error if error is not None else None,
             )
 
-        if self.redirect_route_name:
-            redirect_url = str(request.url_for(self.redirect_route_name))
-        else:
-            redirect_url = self.redirect_uri
-
         try:
             access_token = await self.client.get_access_token(
                 code=code,
-                redirect_uri=redirect_url,
+                redirect_uri=self.redirect_uri,
                 code_verifier=code_verifier,
             )
         except (HTTPXOAuth20Error, AccessTokenError) as e:


### PR DESCRIPTION
This configuration is not applicable to HTTPS.